### PR TITLE
Invasion of the .DS_Store halted.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ hs_err_pid*
 /.project
 /.classpath
 /bin
+
+#mac
+.DS_Store


### PR DESCRIPTION
.DS_Store is a file auto-generated by OS X, to arrange desktop icons and such. Windows users don't like it.
